### PR TITLE
appmenus: fix 'Files' entry for Fedora 21 and 22 (#1206)

### DIFF
--- a/template_scripts/appmenus_fc21/vm-whitelisted-appmenus.list
+++ b/template_scripts/appmenus_fc21/vm-whitelisted-appmenus.list
@@ -1,3 +1,3 @@
 gnome-terminal.desktop
-nautilus.desktop
+org.gnome.Nautilus.desktop
 firefox.desktop

--- a/template_scripts/appmenus_fc22/vm-whitelisted-appmenus.list
+++ b/template_scripts/appmenus_fc22/vm-whitelisted-appmenus.list
@@ -1,3 +1,3 @@
 gnome-terminal.desktop
-nautilus.desktop
+org.gnome.Nautilus.desktop
 firefox.desktop


### PR DESCRIPTION
Nautilus desktop entry was renamed to org.gnome.Nautilus.desktop because
of DBusActivatable usage. We've forgot to change this when preparing
initial Fedora 21 template...

Fixes QubesOS/qubes-issues#1206